### PR TITLE
Lower python version from 3.11 to 3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 <!--next-version-placeholder-->
 
+## v1.1.2 (24/06/2024)
+
+### Fix
+
+- Change python_requires from 3.11 to 3.9
+- Remove monai dependency
+
+
 ## v1.1.0 (18/05/2024)
 
 ### Feature

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 nnunetv2==2.2.1
 argparse==1.4.0
-monai==1.3.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mrsegmentator
-version = 1.1.0
+version = 1.1.2
 author = Hartmut Häntze
 author_email = hartmut.haentze@charite.de
 description = Robust Multi-Modality Segmentation of 40 Classes in MRI and CT Sequences
@@ -25,11 +25,10 @@ classifiers =
 package_dir =
     = src
 packages = find:
-python_requires = >=3.11
+python_requires = >=3.9
 install_requires =
     nnunetv2 == 2.2.1
     argparse
-    monai == 1.3.0
 
 [options.packages.find]
 where = src

--- a/src/mrsegmentator/utils.py
+++ b/src/mrsegmentator/utils.py
@@ -14,12 +14,10 @@
 
 import os
 from pathlib import Path
-from typing import Any, Callable, Iterator, List, Tuple, TypeVar
+from typing import Any, Callable, Iterator, List, Tuple
 
 import numpy as np
 from numpy.typing import NDArray
-
-T = TypeVar("T")
 
 
 def read_images(namespace: Any) -> List[str]:
@@ -41,7 +39,7 @@ def read_images(namespace: Any) -> List[str]:
 
 # Yield successive n-sized
 # chunks from l.
-def divide_chunks(l: List[T], n: int) -> Iterator[List[T]]:  # noqa: E741
+def divide_chunks(l: List, n: int) -> Iterator[List]:  # noqa: E741
     # looping till length l
     for i in range(0, len(l), n):
         yield l[i : i + n]
@@ -79,5 +77,5 @@ def stitch_segmentations(seg1: NDArray, seg2: NDArray, margin: int = 2) -> NDArr
     return seg_combined
 
 
-def flatten(xss: List[List[T] | Tuple[T, ...]]) -> List[T]:
+def flatten(xss):
     return [x for xs in xss for x in xs]


### PR DESCRIPTION
### Lower required python version from 3.11 to 3.9
The only part of the code that required python 3.11 was the generic type [T] for type checking. 
Type checking is an addtional procedure and should not affect the code's compatibility by two major versions.
I removed the generic type from the source code