### PR TITLE
Fix Orientation Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 <!--next-version-placeholder-->
+## v1.3.2 (26/05/2026)
+
+### Fix
+- Fixed incorrect handling of image orientations such as PIL or ASL
 
 ## v1.3.1 (11/08/2025)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = mrsegmentator
-version = 1.3.1
+version = 1.3.2
 author = Hartmut Häntze
 author_email = hartmut.haentze@charite.de
 description = Multi-Modality Segmentation of 40 Classes in MRI and CT

--- a/src/mrsegmentator/simpleitk_reader_writer.py
+++ b/src/mrsegmentator/simpleitk_reader_writer.py
@@ -69,6 +69,7 @@ class SimpleITKIO:
         direction = itk_image.GetDirection()
         orientation = get_orientation_string(itk_image)
         itk_image = sitk.DICOMOrient(itk_image, "LPS")
+        spacing_itk = itk_image.GetSpacing()
 
         # transform image to numpy array
         npy_image = sitk.GetArrayFromImage(itk_image)
@@ -88,7 +89,7 @@ class SimpleITKIO:
             },
             # the spacing is inverted with [::-1] because sitk returns the spacing in the wrong order lol. Image arrays
             # are returned x,y,z but spacing is returned z,y,x. Duh.
-            "spacing": list(spacing)[::-1],
+            "spacing": list(spacing_itk)[::-1],
         }
 
         log(verbose, f"Image Size: {npy_image.shape}\tSpacing: {_dict['spacing']}")


### PR DESCRIPTION
- previously we saved the spacing of the original image, but not the LPS image. This worked correctly for LSP and RAS images, as they sare the same z-axes. However, for orientations with other z-axes this caused serious missalignment
- we save the correct spacing now